### PR TITLE
feat: use remote state management provided by rudder-cli v0.3.0

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - "main"
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          token: ${{ secrets.PAT }}
+          pull-request-title-pattern: "chore: release ${version}"
+          release-type: node
+          package-name: rudder-tracking-plans-action
+          default-branch: ${{ steps.extract_branch.outputs.branch }}
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"refactor","section":"Miscellaneous","hidden":false},{"type":"test","section":"Miscellaneous","hidden":false},{"type":"doc","section":"Documentation","hidden":false}]'
+          bump-minor-pre-major: true

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -7,16 +7,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
       - uses: google-github-actions/release-please-action@v3
         with:
           token: ${{ secrets.PAT }}
           pull-request-title-pattern: "chore: release ${version}"
-          release-type: node
-          package-name: rudder-tracking-plans-action
-          default-branch: ${{ steps.extract_branch.outputs.branch }}
+          release-type: simple
+          package-name: rudder-tracking-plan-action
+          default-branch: main
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"refactor","section":"Miscellaneous","hidden":false},{"type":"test","section":"Miscellaneous","hidden":false},{"type":"doc","section":"Documentation","hidden":false}]'
           bump-minor-pre-major: true

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,49 @@
+name: "Semantic pull requests"
+
+on: pull_request
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            chore
+            refactor
+            exp
+            doc
+            test
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # For work-in-progress PRs you can typically use draft pull requests
+          # from GitHub. However, private repositories on the free plan don't have
+          # this option and therefore this action allows you to opt-in to using the
+          # special "[WIP]" prefix to indicate this state. This will avoid the
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: true
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit message for one commit PRs.
+          validateSingleCommit: true
+          # Related to `validateSingleCommit` you can opt-in to validate that the PR
+          # title matches a single commit to avoid confusion.
+          validateSingleCommitMatchesPrTitle: true
+          # If the PR contains one of these labels, the validation is skipped.
+          # Multiple labels can be separated by newlines.
+          # If you want to rerun the validation when labels change, you might want
+          # to use the `labeled` and `unlabeled` event triggers in your workflow.
+          ignoreLabels: |
+            bot
+            dependencies

--- a/action.yml
+++ b/action.yml
@@ -1,28 +1,25 @@
-name: 'Rudderstack Tracking Plan Manager'
-description: 'Validate and manage Rudderstack tracking plans through GitHub Actions'
-author: 'Your Name'
+name: "Rudderstack Tracking Plan Manager"
+description: "Validate and manage Rudderstack tracking plans through GitHub Actions"
+author: "Your Name"
 
 branding:
-  icon: 'upload-cloud'  
-  color: 'blue'
+  icon: "upload-cloud"
+  color: "blue"
 
 inputs:
-  folder_path:
-    description: 'Path to the folder containing tracking plan files'
+  location:
+    description: "Path to the folder containing tracking plan files"
     required: true
   mode:
-    description: 'Operation mode (review or apply)'
-    required: true
-  access_token:
-    description: 'Rudderstack access token'
+    description: "Operation mode. Must be one of: 'validate', 'dry-run', or 'apply'"
     required: true
   cli_version:
-    description: 'Version of rudder-cli to use'
+    description: "Version of rudder-cli to use"
     required: false
-    default: 'v0.2.0'
+    default: "v0.2.0"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Download Rudder CLI
       shell: bash
@@ -31,29 +28,34 @@ runs:
         chmod +x rudder-cli
         sudo mv rudder-cli /usr/local/bin/
 
-    - name: Create Rudder config directory
-      shell: bash
-      run: mkdir -p ~/.rudder
-
-    - name: Setup Rudder configuration
+    - name: Verify environment
       shell: bash
       run: |
-        echo "{\"auth\":{\"accessToken\":\"${{ inputs.access_token }}\"}}" > ~/.rudder/config.json
+        if [ -z "$RUDDERSTACK_ACCESS_TOKEN" ]; then
+          echo "::error::RUDDERSTACK_ACCESS_TOKEN environment variable is not set. Please set it using repository secrets."
+          exit 1
+        fi
+
+        # Validate mode input
+        if [[ "${{ inputs.mode }}" != "validate" && "${{ inputs.mode }}" != "dry-run" && "${{ inputs.mode }}" != "apply" ]]; then
+          echo "::error::Invalid mode: ${{ inputs.mode }}. Mode must be one of: validate, dry-run, apply"
+          exit 1
+        fi
 
     - name: Validate tracking plan
-      if: inputs.mode == 'review'
+      if: inputs.mode == 'validate'
       shell: bash
       run: |
-        rudder-cli tp validate -l ${{ inputs.folder_path }}
-        
+        rudder-cli tp validate -l ${{ inputs.location }}
+
     - name: Perform dry run
-      if: inputs.mode == 'validate-dry-run'
+      if: inputs.mode == 'dry-run'
       shell: bash
       run: |
-        rudder-cli tp apply -l ${{ inputs.folder_path }} --dry-run
+        rudder-cli tp apply -l ${{ inputs.location }} --dry-run
 
     - name: Apply tracking plan
       if: inputs.mode == 'apply'
       shell: bash
       run: |
-        rudder-cli tp apply -l ${{ inputs.folder_path }}
+        rudder-cli tp apply -l ${{ inputs.location }}

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,9 @@
 name: "Rudderstack Tracking Plan Manager"
 description: "Validate and manage Rudderstack tracking plans through GitHub Actions"
-author: "Your Name"
 
 branding:
-  icon: "upload-cloud"
-  color: "blue"
+  icon: activity
+  color: purple
 
 inputs:
   location:
@@ -52,7 +51,7 @@ runs:
           exit 1
         fi
 
-    - name: Validate tracking plan
+    - name: Validate tracking plans
       if: inputs.mode == 'validate'
       shell: bash
       run: |
@@ -64,7 +63,7 @@ runs:
       run: |
         rudder-cli tp apply -l ${{ inputs.location }} --dry-run
 
-    - name: Apply tracking plan
+    - name: Apply tracking plans
       if: inputs.mode == 'apply'
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -58,4 +58,4 @@ runs:
       if: inputs.mode == 'apply'
       shell: bash
       run: |
-        rudder-cli tp apply -l ${{ inputs.location }}
+        rudder-cli tp apply -l ${{ inputs.location }} --confirm=false

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   cli_version:
     description: "Version of rudder-cli to use"
     required: false
-    default: "v0.2.0"
+    default: "v0.3.0"
 
 runs:
   using: "composite"
@@ -24,6 +24,16 @@ runs:
     - name: Download Rudder CLI
       shell: bash
       run: |
+        # Validate minimum CLI version
+        required_version="0.3.0"
+        input_version="${{ inputs.cli_version }}"
+        input_version="${input_version#v}" # Remove 'v' prefix if present
+
+        if ! printf '%s\n' "$required_version" "$input_version" | sort -V -C; then
+          echo "::error::CLI version must be at least v${required_version}. Got: ${{ inputs.cli_version }}"
+          exit 1
+        fi
+
         curl -L https://github.com/rudderlabs/rudder-iac/releases/download/${{ inputs.cli_version }}/rudder-cli_Linux_x86_64.tar.gz | tar -xz rudder-cli
         chmod +x rudder-cli
         sudo mv rudder-cli /usr/local/bin/

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate Tracking Plans
-        uses: rudderlabs/rudder-tracking-plans-action@v1.0.0
+        uses: rudderlabs/rudder-tracking-plan-action@v1.0.0
         env:
           RUDDERSTACK_ACCESS_TOKEN: ${{ secrets.RUDDER_ACCESS_TOKEN }}
         with:
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Apply Tracking Plans
-        uses: rudderlabs/rudder-tracking-plans-action@v1.0.0
+        uses: rudderlabs/rudder-tracking-plan-action@v1.0.0
         env:
           RUDDERSTACK_ACCESS_TOKEN: ${{ secrets.RUDDER_ACCESS_TOKEN }}
         with:

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate Tracking Plans
-        uses: your-username/rudderstack-tracking-plan-action@v1
+        uses: rudderlabs/rudder-tracking-plans-action@v1.0.0
         env:
           RUDDERSTACK_ACCESS_TOKEN: ${{ secrets.RUDDER_ACCESS_TOKEN }}
         with:
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Apply Tracking Plans
-        uses: your-username/rudderstack-tracking-plan-action@v1
+        uses: rudderlabs/rudder-tracking-plans-action@v1.0.0
         env:
           RUDDERSTACK_ACCESS_TOKEN: ${{ secrets.RUDDER_ACCESS_TOKEN }}
         with:

--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,9 @@ name: Manage Tracking Plans
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   validate:
@@ -34,10 +34,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate Tracking Plans
         uses: your-username/rudderstack-tracking-plan-action@v1
+        env:
+          RUDDERSTACK_ACCESS_TOKEN: ${{ secrets.RUDDER_ACCESS_TOKEN }}
         with:
-          folder_path: 'tracking-plans/'
-          mode: 'review'
-          access_token: ${{ secrets.RUDDER_ACCESS_TOKEN }}
+          location: "tracking-plans/"
+          mode: "validate"
 
   apply:
     runs-on: ubuntu-latest
@@ -47,34 +48,45 @@ jobs:
       - uses: actions/checkout@v4
       - name: Apply Tracking Plans
         uses: your-username/rudderstack-tracking-plan-action@v1
+        env:
+          RUDDERSTACK_ACCESS_TOKEN: ${{ secrets.RUDDER_ACCESS_TOKEN }}
         with:
-          folder_path: 'tracking-plans/'
-          mode: 'apply'
-          access_token: ${{ secrets.RUDDER_ACCESS_TOKEN }}
+          location: "tracking-plans/"
+          mode: "apply"
 ```
 
 ### Inputs
 
-| Input | Description | Required | Default |
-|-------|-------------|----------|---------|
-| `folder_path` | Path to the folder containing tracking plan files | Yes | N/A |
-| `mode` | Operation mode (`review` or `apply`) | Yes | N/A |
-| `access_token` | Rudderstack access token | Yes | N/A |
-| `cli_version` | Version of rudder-cli to use | No | v0.2.0 |
+| Input         | Description                                        | Required | Default |
+| ------------- | -------------------------------------------------- | -------- | ------- |
+| `location`    | Path to the folder containing tracking plan files  | Yes      | N/A     |
+| `mode`        | Operation mode (`validate`, `dry-run`, or `apply`) | Yes      | N/A     |
+| `cli_version` | Version of rudder-cli to use                       | No       | v0.2.0  |
+
+### Environment Variables
+
+| Variable                   | Description              | Required |
+| -------------------------- | ------------------------ | -------- |
+| `RUDDERSTACK_ACCESS_TOKEN` | Rudderstack access token | Yes      |
 
 ### Modes
 
-1. **review**: 
-   - Validates tracking plan syntax
-   - Performs a dry run of changes
-   - No actual changes are applied
+1. **validate**:
 
-2. **apply**:
+   - Validates tracking plan syntax and structure
+   - No changes are applied to your configuration
+
+2. **dry-run**:
+
+   - Simulates the application of changes
+   - Shows what would be modified without making actual changes
+
+3. **apply**:
    - Applies the tracking plan changes to your Rudderstack configuration
 
 ## Security
 
-The action securely handles your Rudderstack access token. Always store your access token in GitHub Secrets and never expose it in your workflow files.
+The action requires your Rudderstack access token to be provided via the `RUDDERSTACK_ACCESS_TOKEN` environment variable. Always store this token in GitHub Secrets and reference it in your workflow using `${{ secrets.YOUR_SECRET_NAME }}`. Never expose the token directly in your workflow files.
 
 ## License
 


### PR DESCRIPTION
## Description of the change

- updated default rudder-cli version to v0.3.0
- changed input parameter `folder_path` to `location`, and `mode` values to better match the arguments of rudder-cli
- rudder-cli's token is now expected to be passed as an env variable, which should be set through a secret
- added validations to ensure minimum rudder-cli version (v0.3.0) and the existence of RUDDERSTACK_ACCESS_TOKEN env

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
