### PR TITLE
fix: download url to download cli when cli_version is configured by user

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
           exit 1
         fi
 
-        curl -L https://github.com/rudderlabs/rudder-iac/releases/download/${{ inputs.cli_version }}/rudder-cli_Linux_x86_64.tar.gz | tar -xz rudder-cli
+        curl -L https://github.com/rudderlabs/rudder-iac/releases/download/v${{ input_version }}/rudder-cli_Linux_x86_64.tar.gz | tar -xz rudder-cli
         chmod +x rudder-cli
         sudo mv rudder-cli /usr/local/bin/
 


### PR DESCRIPTION
## Description of the change

The url constructed to download the cli when cli-version is configured as found in https://github.com/rudderlabs/dodds-cli-data-gov/actions/runs/15197349325/job/42744691966#step:3:104 is 
https://github.com/rudderlabs/rudder-iac/releases/download/0.6.0/rudder-cli_Linux_x86_64.tar.gz

But expected is
https://github.com/rudderlabs/rudder-iac/releases/download/v0.6.0/rudder-cli_Linux_x86_64.tar.gz
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
